### PR TITLE
skip <DiscussionThreading> tag

### DIFF
--- a/mwxml/iteration/page.py
+++ b/mwxml/iteration/page.py
@@ -79,12 +79,12 @@ class Page(mwtypes.Page):
             elif tag == "revision":
                 first_revision = sub_element
                 break
-            elif tag == "discussionthreadinginfo":
-                logger.warning(
-                    "Encountered <discussionthreadinginfo> and skipping it...")
             # Assuming that the first revision seen marks the end of page
             # metadata.  I'm not too keen on this assumption, so I'm leaving
             # this long comment to warn whoever ends up maintaining this.
+            elif tag == "DiscussionThreading":
+                logger.warning(
+                    "Encountered <DiscussionThreading> and skipping it ...")
             else:
                 raise MalformedXML("Unexpected tag found when processing " +
                                    "a <page>: '{0}'".format(tag))

--- a/mwxml/iteration/tests/test_page.py
+++ b/mwxml/iteration/tests/test_page.py
@@ -87,9 +87,10 @@ def test_page_with_discussion():
     XML = """
     <page>
         <title>Talk:AccessibleComputing</title>
+        <ns>90</ns>
         <id>10</id>
         <redirect title="Computer accessibility" />
-        <discussionthreadinginfo>
+        <DiscussionThreading>
           <ThreadSubject>Foo</ThreadSubject>
           <ThreadParent>1</ThreadParent>
           <ThreadAncestor>2</ThreadAncestor>
@@ -98,7 +99,7 @@ def test_page_with_discussion():
           <ThreadAuthor>Baz</ThreadAuthor>
           <ThreadEditStatus>Herp</ThreadEditStatus>
           <ThreadType>Derp</ThreadType>
-        </discussionthreadinginfo>
+        </DiscussionThreading>
         <revision>
           <id>862220</id>
           <parentid>233192</parentid>


### PR DESCRIPTION
Fix #5 , skip `<DiscussionThreading>` tag instead of `<discussionthreadinginfo>`.