### PR TITLE
Enables parsing a page when site_info has no namespaces

### DIFF
--- a/mwxml/iteration/dump.py
+++ b/mwxml/iteration/dump.py
@@ -121,9 +121,8 @@ class Dump:
                 raise MalformedXML("Unexpected tag found when processing " +
                                    "a <mediawiki>: '{0}'".format(tag))
 
-        namespace_map = None
+        namespace_map = {}
         if site_info.namespaces is not None:
-            namespace_map = {}
             for namespace in site_info.namespaces:
                 namespace_map[namespace.name] = namespace
 


### PR DESCRIPTION
I don't really know anything about MediaWiki; this is just a solution to a problem I hit while hacking.. apologies if it's a bad solution!

----

The default header/footer used by Dump.from_page_xml to wrap a <page> element in
a bare-bones <mediawiki> element doesn't contain any namespaces. That means that
the namespace_map in Dump.from_element is None.

When you start iterating through Dump.pages, that eventually leads to a
TypeError in page.extract_namespace.

This commit just makes {} the fallback value for the namespace map to fix that
particular issue.