### PR TITLE
Missing origin attr added per 0.11 xsd

### DIFF
--- a/mwxml/iteration/revision.py
+++ b/mwxml/iteration/revision.py
@@ -23,6 +23,7 @@ class Revision(mwtypes.Revision):
         user = None
         user_deleted = False
         minor = False
+        origin = None
         comment = None
         comment_deleted = False
         text = None
@@ -49,6 +50,8 @@ class Revision(mwtypes.Revision):
                     user = User.from_element(sub_element)
             elif tag == "minor":
                 minor = True
+            elif tag == "origin":
+                origin = sub_element.text
             elif tag == "sha1":
                 sha1 = sub_element.text
             elif tag == "parentid":


### PR DESCRIPTION
Missing origin attr added per 0.11 xsd, otherwise mwtypes breaks.