### PR TITLE
migrate from nose to pytest

### DIFF
--- a/mwxml/iteration/page.py
+++ b/mwxml/iteration/page.py
@@ -96,7 +96,7 @@ class Page(mwtypes.Page):
         # Normalize title and extract namespace
         mapped_namespace, title = extract_namespace(page_name, namespace_map)
         if namespace is not None and mapped_namespace != namespace:
-            logger.warn("Namespace id conflict detected.  " +
+            logger.warning("Namespace id conflict detected.  " +
                         "<title>={0}, ".format(page_name) +
                         "<namespace>={0}, ".format(namespace) +
                         "mapped_namespace={0}".format(mapped_namespace))

--- a/mwxml/iteration/tests/test_dump.py
+++ b/mwxml/iteration/tests/test_dump.py
@@ -1,8 +1,6 @@
 import io
 
 import mwtypes
-from nose.tools import assert_is_instance, eq_
-
 from ..dump import Dump
 from ..page import Page
 from ..revision import Revision
@@ -59,40 +57,40 @@ def test_complete():
     f = io.StringIO(SAMPLE_XML)
 
     dump = Dump.from_file(f)
-    eq_([0, 1], list(ns.id for ns in dump.site_info.namespaces))
+    assert [0, 1] == list(ns.id for ns in dump.site_info.namespaces)
 
     page = next(dump)
-    eq_(page.title, "Foo")
-    eq_(page.namespace, 0)
-    eq_(page.id, 1)
-    eq_(page.redirect, None)
-    eq_(page.restrictions, [])
+    assert page.title == "Foo"
+    assert page.namespace == 0
+    assert page.id == 1
+    assert page.redirect == None
+    assert page.restrictions == []
 
     revision = next(page)
-    eq_(revision.id, 1)
-    eq_(revision.timestamp, mwtypes.Timestamp("2004-08-09T09:04:08Z"))
+    assert revision.id == 1
+    assert revision.timestamp == mwtypes.Timestamp("2004-08-09T09:04:08Z")
 
     revision = next(page)
-    eq_(revision.id, 2)
-    eq_(revision.timestamp, mwtypes.Timestamp("2004-08-10T09:04:08Z"))
+    assert revision.id == 2
+    assert revision.timestamp == mwtypes.Timestamp("2004-08-10T09:04:08Z")
 
     page = next(dump)
-    assert_is_instance(page, Page)
-    eq_(page.title, "Bar")
-    eq_(page.namespace, 1)
-    eq_(page.id, 2)
-    eq_(page.redirect, "Computer accessibility")
-    eq_(page.restrictions, ["edit=sysop:move=sysop"])
+    assert isinstance(page, Page)
+    assert page.title == "Bar"
+    assert page.namespace == 1
+    assert page.id == 2
+    assert page.redirect == "Computer accessibility"
+    assert page.restrictions == ["edit=sysop:move=sysop"]
 
     revision = next(page)
-    assert_is_instance(revision, Revision)
-    eq_(revision.id, 3)
-    eq_(revision.timestamp, mwtypes.Timestamp("2004-08-11T09:04:08Z"))
+    assert isinstance(revision, Revision)
+    assert revision.id == 3
+    assert revision.timestamp == mwtypes.Timestamp("2004-08-11T09:04:08Z")
 
     revision = next(page)
-    assert_is_instance(revision, Revision)
-    eq_(revision.id, 4)
-    eq_(revision.timestamp, mwtypes.Timestamp("2004-08-12T09:04:08Z"))
+    assert isinstance(revision, Revision)
+    assert revision.id == 4
+    assert revision.timestamp == mwtypes.Timestamp("2004-08-12T09:04:08Z")
 
 
 def test_skipping():
@@ -101,18 +99,18 @@ def test_skipping():
     dump = Dump.from_file(f)
 
     page = next(dump)
-    eq_(page.title, "Foo")
-    eq_(page.namespace, 0)
-    eq_(page.id, 1)
+    assert page.title == "Foo"
+    assert page.namespace == 0
+    assert page.id == 1
 
     page = next(dump)
-    eq_(page.title, "Bar")
-    eq_(page.namespace, 1)
-    eq_(page.id, 2)
+    assert page.title == "Bar"
+    assert page.namespace == 1
+    assert page.id == 2
 
     revision = next(page)
-    eq_(revision.id, 3)
-    eq_(revision.timestamp, mwtypes.Timestamp("2004-08-11T09:04:08Z"))
+    assert revision.id == 3
+    assert revision.timestamp == mwtypes.Timestamp("2004-08-11T09:04:08Z")
 
 
 def test_from_page_xml():
@@ -135,20 +133,20 @@ def test_from_page_xml():
     dump = Dump.from_page_xml(io.StringIO(page_xml))
 
     # You have a `namespaces`, but it's empty.
-    eq_(dump.site_info.namespaces, None)
+    assert dump.site_info.namespaces == None
 
     page = next(dump)
-    eq_(page.title, "Foo")
-    eq_(page.namespace, 0)
-    eq_(page.id, 1)
+    assert page.title == "Foo"
+    assert page.namespace == 0
+    assert page.id == 1
 
     revision = next(page)
-    eq_(revision.id, 1)
-    eq_(revision.timestamp, mwtypes.Timestamp("2004-08-09T09:04:08Z"))
+    assert revision.id == 1
+    assert revision.timestamp == mwtypes.Timestamp("2004-08-09T09:04:08Z")
 
     revision = next(page)
-    eq_(revision.id, 2)
-    eq_(revision.timestamp, mwtypes.Timestamp("2004-08-10T09:04:08Z"))
+    assert revision.id == 2
+    assert revision.timestamp == mwtypes.Timestamp("2004-08-10T09:04:08Z")
 
 
 OLD_XML = """
@@ -189,7 +187,7 @@ def test_old_dump():
 
     page = next(dump)
 
-    eq_(page.namespace, 1)
+    assert page.namespace == 1
 
 
 LOG_XML = """
@@ -243,7 +241,7 @@ def test_log_dump():
     dump = Dump.from_file(f)
 
     log_item = next(dump)
-    eq_(log_item.id, 1)
+    assert log_item.id == 1
 
     log_item = next(dump)
-    eq_(log_item.id, 2)
+    assert log_item.id == 2

--- a/mwxml/iteration/tests/test_log_item.py
+++ b/mwxml/iteration/tests/test_log_item.py
@@ -1,6 +1,4 @@
 from mwtypes import Timestamp
-from nose.tools import eq_
-
 from ...element_iterator import ElementIterator
 from ..log_item import LogItem
 from ..namespace import Namespace
@@ -26,22 +24,22 @@ def test_log_item():
         "Template": Namespace(10, "Template")}
     log_item = LogItem.from_element(
         ElementIterator.from_string(XML), namespace_map)
-    eq_(log_item.id, 6)
-    eq_(log_item.timestamp, Timestamp("2004-12-23T03:34:26Z"))
-    eq_(log_item.comment,
+    assert log_item.id == 6
+    assert log_item.timestamp == Timestamp("2004-12-23T03:34:26Z")
+    assert (log_item.comment ==
         "content was: '#redirect [[Template:UserBrockert]]', an old " +
         "experiment of mine, now being moved around by bots")
-    eq_(log_item.user.id, 50095)
-    eq_(log_item.user.text, "Brockert")
-    eq_(log_item.page.namespace, 10)
-    eq_(log_item.page.title, "UserBrockert")
-    eq_(log_item.type, "delete")
-    eq_(log_item.action, "delete")
-    eq_(log_item.params, None)
-    eq_(log_item.deleted.action, None)
-    eq_(log_item.deleted.user, False)
-    eq_(log_item.deleted.comment, False)
-    eq_(log_item.deleted.restricted, None)
+    assert log_item.user.id == 50095
+    assert log_item.user.text == "Brockert"
+    assert log_item.page.namespace == 10
+    assert log_item.page.title == "UserBrockert"
+    assert log_item.type == "delete"
+    assert log_item.action == "delete"
+    assert log_item.params == None
+    assert log_item.deleted.action == None
+    assert log_item.deleted.user == False
+    assert log_item.deleted.comment == False
+    assert log_item.deleted.restricted == None
 
     NULL_TITLE_XML = """
     <logitem>
@@ -60,5 +58,5 @@ def test_log_item():
     """  # noqa
     log_item = LogItem.from_element(
         ElementIterator.from_string(NULL_TITLE_XML))
-    eq_(log_item.page.namespace, None)
-    eq_(log_item.page.title, None)
+    assert log_item.page.namespace == None
+    assert log_item.page.title == None

--- a/mwxml/iteration/tests/test_namespace.py
+++ b/mwxml/iteration/tests/test_namespace.py
@@ -1,5 +1,3 @@
-from nose.tools import eq_
-
 from ...element_iterator import ElementIterator
 from ..namespace import Namespace
 
@@ -7,16 +5,16 @@ from ..namespace import Namespace
 def test_namespace():
     XML = '<namespace key="0" case="first-letter" />'
     namespace = Namespace.from_element(ElementIterator.from_string(XML))
-    eq_(namespace.id, 0)
-    eq_(namespace.name, "")
-    eq_(namespace.aliases, None)
-    eq_(namespace.case, "first-letter")
-    eq_(namespace.canonical, None)
+    assert namespace.id == 0
+    assert namespace.name == ""
+    assert namespace.aliases == None
+    assert namespace.case == "first-letter"
+    assert namespace.canonical == None
 
     XML = '<namespace key="711" case="first-letter">TimedText talk</namespace>'
     namespace = Namespace.from_element(ElementIterator.from_string(XML))
-    eq_(namespace.id, 711)
-    eq_(namespace.name, "TimedText talk")
-    eq_(namespace.aliases, None)
-    eq_(namespace.case, "first-letter")
-    eq_(namespace.canonical, None)
+    assert namespace.id == 711
+    assert namespace.name == "TimedText talk"
+    assert namespace.aliases == None
+    assert namespace.case == "first-letter"
+    assert namespace.canonical == None

--- a/mwxml/iteration/tests/test_page.py
+++ b/mwxml/iteration/tests/test_page.py
@@ -1,5 +1,3 @@
-from nose.tools import eq_
-
 from ...element_iterator import ElementIterator
 from ..namespace import Namespace
 from ..page import Page
@@ -43,18 +41,18 @@ def test_page():
     </page>
     """
     page = Page.from_element(ElementIterator.from_string(XML))
-    eq_(page.id, 10)
-    eq_(page.title, "AccessibleComputing")
-    eq_(page.namespace, 0)
-    eq_(page.redirect, "Computer accessibility")
-    eq_(page.restrictions, [])  # Should be known to be empty
+    assert page.id == 10
+    assert page.title == "AccessibleComputing"
+    assert page.namespace == 0
+    assert page.redirect == "Computer accessibility"
+    assert page.restrictions == []  # Should be known to be empty
 
     revision = next(page)
-    eq_(revision.id, 233192)
-    eq_(revision.page, page)
+    assert revision.id == 233192
+    assert revision.page == page
 
     revision = next(page)
-    eq_(revision.id, 862220)
+    assert revision.id == 862220
 
 
 def test_old_page():
@@ -80,7 +78,7 @@ def test_old_page():
     """
     page = Page.from_element(ElementIterator.from_string(XML),
                              {"Talk": Namespace(1, "Talk")})
-    eq_(page.namespace, 1)
+    assert page.namespace == 1
 
 
 def test_page_with_discussion():
@@ -119,7 +117,7 @@ def test_page_with_discussion():
     """
     page = Page.from_element(ElementIterator.from_string(XML),
                              {"Talk": Namespace(1, "Talk")})
-    eq_(page.namespace, 1)
+    assert page.namespace == 1
 
     revision = next(page)
-    eq_(revision.id, 862220)
+    assert revision.id == 862220

--- a/mwxml/iteration/tests/test_revision.py
+++ b/mwxml/iteration/tests/test_revision.py
@@ -1,6 +1,4 @@
 import mwtypes
-from nose.tools import eq_
-
 from ...element_iterator import ElementIterator
 from ..revision import Revision
 
@@ -23,19 +21,19 @@ def test_old_revision():
     </revision>
     """
     revision = Revision.from_element(ElementIterator.from_string(XML))
-    eq_(revision.id, 233192)
-    eq_(revision.timestamp, mwtypes.Timestamp("2001-01-21T02:12:21Z"))
-    eq_(revision.user.id, 99)
-    eq_(revision.user.text, "RoseParks")
-    eq_(revision.comment, "*")
-    eq_(revision.minor, True)
-    eq_(revision.model, "wikitext")
-    eq_(revision.format, "text/x-wiki")
-    eq_(revision.text, "Text of rev 233192")
-    eq_(revision.sha1, "8kul9tlwjm9oxgvqzbwuegt9b2830vw")
-    eq_(revision.deleted.text, False)
-    eq_(revision.deleted.comment, False)
-    eq_(revision.deleted.user, False)
+    assert revision.id == 233192
+    assert revision.timestamp == mwtypes.Timestamp("2001-01-21T02:12:21Z")
+    assert revision.user.id == 99
+    assert revision.user.text == "RoseParks"
+    assert revision.comment == "*"
+    assert revision.minor == True
+    assert revision.model == "wikitext"
+    assert revision.format == "text/x-wiki"
+    assert revision.text == "Text of rev 233192"
+    assert revision.sha1 == "8kul9tlwjm9oxgvqzbwuegt9b2830vw"
+    assert revision.deleted.text == False
+    assert revision.deleted.comment == False
+    assert revision.deleted.user == False
 
     XML = """
     <revision>
@@ -51,12 +49,12 @@ def test_old_revision():
     </revision>
     """
     revision = Revision.from_element(ElementIterator.from_string(XML))
-    eq_(revision.user, None)
-    eq_(revision.comment, None)
-    eq_(revision.text, None)
-    eq_(revision.deleted.text, True)
-    eq_(revision.deleted.comment, True)
-    eq_(revision.deleted.user, True)
+    assert revision.user == None
+    assert revision.comment == None
+    assert revision.text == None
+    assert revision.deleted.text == True
+    assert revision.deleted.comment == True
+    assert revision.deleted.user == True
 
 
 def test_new_revision():
@@ -85,30 +83,30 @@ def test_new_revision():
     </revision>
     """  # noqa
     revision = Revision.from_element(ElementIterator.from_string(XML))
-    eq_(revision.id, 233192)
-    eq_(revision.timestamp, mwtypes.Timestamp("2001-01-21T02:12:21Z"))
-    eq_(revision.user.id, 99)
-    eq_(revision.user.text, "RoseParks")
-    eq_(revision.comment, "*")
-    eq_(revision.minor, True)
-    eq_(revision.model, "wikitext")
-    eq_(revision.format, "text/x-wiki")
-    eq_(revision.text, "Text of rev 233192")
-    eq_(revision.sha1, "8kul9tlwjm9oxgvqzbwuegt9b2830vw")
-    eq_(revision.deleted.text, True)
-    eq_(revision.deleted.comment, False)
-    eq_(revision.deleted.user, False)
-    eq_(revision.slots.sha1, "93284629347293")
-    eq_(revision.slots['main'].sha1,
+    assert revision.id == 233192
+    assert revision.timestamp == mwtypes.Timestamp("2001-01-21T02:12:21Z")
+    assert revision.user.id == 99
+    assert revision.user.text == "RoseParks"
+    assert revision.comment == "*"
+    assert revision.minor == True
+    assert revision.model == "wikitext"
+    assert revision.format == "text/x-wiki"
+    assert revision.text == "Text of rev 233192"
+    assert revision.sha1 == "8kul9tlwjm9oxgvqzbwuegt9b2830vw"
+    assert revision.deleted.text == True
+    assert revision.deleted.comment == False
+    assert revision.deleted.user == False
+    assert revision.slots.sha1 == "93284629347293"
+    assert (revision.slots['main'].sha1 ==
         "8kul9tlwjm9oxgvqzbwuegt9b2830vw")
-    eq_(revision.slots['main'].text, "Text of rev 233192")
-    eq_(revision.slots['main'].format, "text/x-wiki")
-    eq_(revision.slots['label_data'].role, "label_data")
-    eq_(revision.slots['label_data'].origin, 123)
-    eq_(revision.slots['label_data'].model, "JadeEntity")
-    eq_(revision.slots['label_data'].format, "text/json")
-    eq_(revision.slots['label_data'].id, "1234")
-    eq_(revision.slots['label_data'].deleted, True)
-    eq_(revision.slots['label_data'].location, "file://dev/null")
-    eq_(revision.slots['label_data'].bytes, 234)
-    eq_(revision.slots['label_data'].sha1, "ahgsvdjasvbdj3723")
+    assert revision.slots['main'].text == "Text of rev 233192"
+    assert revision.slots['main'].format == "text/x-wiki"
+    assert revision.slots['label_data'].role == "label_data"
+    assert revision.slots['label_data'].origin == 123
+    assert revision.slots['label_data'].model == "JadeEntity"
+    assert revision.slots['label_data'].format == "text/json"
+    assert revision.slots['label_data'].id == "1234"
+    assert revision.slots['label_data'].deleted == True
+    assert revision.slots['label_data'].location == "file://dev/null"
+    assert revision.slots['label_data'].bytes == 234
+    assert revision.slots['label_data'].sha1 == "ahgsvdjasvbdj3723"

--- a/mwxml/iteration/tests/test_user.py
+++ b/mwxml/iteration/tests/test_user.py
@@ -1,5 +1,3 @@
-from nose.tools import eq_
-
 from ...element_iterator import ElementIterator
 from ..user import User
 
@@ -12,8 +10,8 @@ def test_user():
     </contributor>
     """
     user = User.from_element(ElementIterator.from_string(XML))
-    eq_(user.id, 92182)
-    eq_(user.text, "Gen0cide")
+    assert user.id == 92182
+    assert user.text == "Gen0cide"
 
     XML = """
     <contributor>
@@ -21,8 +19,8 @@ def test_user():
     </contributor>
     """
     user = User.from_element(ElementIterator.from_string(XML))
-    eq_(user.id, None)
-    eq_(user.text, "192.168.0.1")
+    assert user.id == None
+    assert user.text == "192.168.0.1"
 
     XML = """
     <contributor>
@@ -31,5 +29,5 @@ def test_user():
     </contributor>
     """
     user = User.from_element(ElementIterator.from_string(XML))
-    eq_(user.id, 0)
-    eq_(user.text, "None")
+    assert user.id == 0
+    assert user.text == "None"

--- a/mwxml/map/tests/test_map.py
+++ b/mwxml/map/tests/test_map.py
@@ -1,5 +1,6 @@
 import io
 
+import pytest
 
 from ..map import map
 
@@ -69,18 +70,18 @@ def test_map():
     assert pages == 2
 
 
-@raises(TypeError)
 def test_map_error():
-    f = io.StringIO(SAMPLE_XML)
+    with pytest.raises(TypeError):
+        f = io.StringIO(SAMPLE_XML)
 
-    def process_dump(dump, path):
-        for page in dump:
+        def process_dump(dump, path):
+            for page in dump:
 
-            if page.id == 2:
-                raise TypeError("Fake error")
+                if page.id == 2:
+                    raise TypeError("Fake error")
 
-    for doc in map([f], process_dump):
-        assert 'page_id' in doc
+        for doc in map([f], process_dump):
+            assert 'page_id' in doc
 
 
 def test_map_error_handler():
@@ -114,75 +115,75 @@ def test_map_error_handler():
     assert pages == 2
 
 
-@raises(ValueError)
 def test_complex_error_handler():
-    f_clean = io.StringIO("""
-        <mediawiki xmlns="http://www.mediawiki.org/xml/export-0.8/"
-                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                   xsi:schemaLocation="http://www.mediawiki.org/xml/export-0.8/
-                   http://www.mediawiki.org/xml/export-0.8.xsd"
-                   version="0.8" xml:lang="en">
-          <siteinfo>
-            <sitename>Wikipedia</sitename>
-            <base>http://en.wikipedia.org/wiki/Main_Page</base>
-            <generator>MediaWiki 1.22wmf2</generator>
-            <case>first-letter</case>
-            <namespaces>
-              <namespace key="0" case="first-letter" />
-              <namespace key="1" case="first-letter">Talk</namespace>
-            </namespaces>
-          </siteinfo>
-          <page>
-            <title>Foo</title>
-            <ns>0</ns>
-            <id>1</id>
-            <revision>
-              <id>1</id>
-              <timestamp>2004-08-09T09:04:08Z</timestamp>
-            </revision>
-            <revision>
-              <id>2</id>
-              <timestamp>2004-08-10T09:04:08Z</timestamp>
-            </revision>
-          </page>
-        </mediawiki>
-    """)
-    f_messy = io.StringIO("""
-        <mediawiki xmlns="http://www.mediawiki.org/xml/export-0.8/"
-                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                   xsi:schemaLocation="http://www.mediawiki.org/xml/export-0.8/
-                   http://www.mediawiki.org/xml/export-0.8.xsd"
-                   version="0.8" xml:lang="en">
-          <siteinfo>
-            <sitename>Wikipedia</sitename>
-            <base>http://en.wikipedia.org/wiki/Main_Page</base>
-            <generator>MediaWiki 1.22wmf2</generator>
-            <case>first-letter</case>
-            <namespaces>
-              <namespace key="0" case="first-letter" />
-              <namespace key="1" case="first-letter">Talk</namespace>
-            </namespaces>
-          </siteinfo>
-          <page>
-            <title>Bar</title>
-            <ns>0</ns>
-            <id>2</id>
-            <revision>
-              <id>3</id>
-              <timestamp>MESSY</timestamp>
-            </revision>
-            <revision>
-              <id>4</id>
-              <timestamp>2004-08-10T09:04:08Z</timestamp>
-            </revision>
-          </page>
-        </mediawiki>
-    """)
-
-    def process_dump(dump, path):
-        for page in dump:
-            for revision in page:
-                yield revision
-
-    for rev in map(process_dump, [f_messy, f_clean], threads=1):
-        print(rev.to_json())
+    with pytest.raises(ValueError):
+        f_clean = io.StringIO("""
+            <mediawiki xmlns="http://www.mediawiki.org/xml/export-0.8/"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xsi:schemaLocation="http://www.mediawiki.org/xml/export-0.8/
+                       http://www.mediawiki.org/xml/export-0.8.xsd"
+                       version="0.8" xml:lang="en">
+              <siteinfo>
+                <sitename>Wikipedia</sitename>
+                <base>http://en.wikipedia.org/wiki/Main_Page</base>
+                <generator>MediaWiki 1.22wmf2</generator>
+                <case>first-letter</case>
+                <namespaces>
+                  <namespace key="0" case="first-letter" />
+                  <namespace key="1" case="first-letter">Talk</namespace>
+                </namespaces>
+              </siteinfo>
+              <page>
+                <title>Foo</title>
+                <ns>0</ns>
+                <id>1</id>
+                <revision>
+                  <id>1</id>
+                  <timestamp>2004-08-09T09:04:08Z</timestamp>
+                </revision>
+                <revision>
+                  <id>2</id>
+                  <timestamp>2004-08-10T09:04:08Z</timestamp>
+                </revision>
+              </page>
+            </mediawiki>
+        """)
+        f_messy = io.StringIO("""
+            <mediawiki xmlns="http://www.mediawiki.org/xml/export-0.8/"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xsi:schemaLocation="http://www.mediawiki.org/xml/export-0.8/
+                       http://www.mediawiki.org/xml/export-0.8.xsd"
+                       version="0.8" xml:lang="en">
+              <siteinfo>
+                <sitename>Wikipedia</sitename>
+                <base>http://en.wikipedia.org/wiki/Main_Page</base>
+                <generator>MediaWiki 1.22wmf2</generator>
+                <case>first-letter</case>
+                <namespaces>
+                  <namespace key="0" case="first-letter" />
+                  <namespace key="1" case="first-letter">Talk</namespace>
+                </namespaces>
+              </siteinfo>
+              <page>
+                <title>Bar</title>
+                <ns>0</ns>
+                <id>2</id>
+                <revision>
+                  <id>3</id>
+                  <timestamp>MESSY</timestamp>
+                </revision>
+                <revision>
+                  <id>4</id>
+                  <timestamp>2004-08-10T09:04:08Z</timestamp>
+                </revision>
+              </page>
+            </mediawiki>
+        """)
+    
+        def process_dump(dump, path):
+            for page in dump:
+                for revision in page:
+                    yield revision
+    
+        for rev in map(process_dump, [f_messy, f_clean], threads=1):
+            print(rev.to_json())

--- a/mwxml/map/tests/test_map.py
+++ b/mwxml/map/tests/test_map.py
@@ -1,6 +1,5 @@
 import io
 
-from nose.tools import eq_, raises
 
 from ..map import map
 
@@ -59,15 +58,15 @@ def test_map():
         page_id = doc['page_id']
         revisions = doc['revisions']
         if page_id == 1:
-            eq_(revisions, 2)
+            assert revisions == 2
         elif page_id == 2:
-            eq_(revisions, 1)
+            assert revisions == 1
         else:
             assert False
 
         pages += 1
 
-    eq_(pages, 2)
+    assert pages == 2
 
 
 @raises(TypeError)
@@ -104,15 +103,15 @@ def test_map_error_handler():
         page_id = doc['page_id']
         revisions = doc['revisions']
         if page_id == 1:
-            eq_(revisions, 2)
+            assert revisions == 2
         elif page_id == 2:
-            eq_(revisions, 1)
+            assert revisions == 1
         else:
             assert False
 
         pages += 1
 
-    eq_(pages, 2)
+    assert pages == 2
 
 
 @raises(ValueError)

--- a/mwxml/tests/test_element_iterator.py
+++ b/mwxml/tests/test_element_iterator.py
@@ -1,7 +1,5 @@
 import io
 
-from nose.tools import eq_
-
 from ..element_iterator import ElementIterator, EventPointer
 
 
@@ -18,61 +16,61 @@ TEST_XML = """
 def test_pointer():
     pointer = EventPointer.from_file(io.StringIO(TEST_XML))
 
-    eq_(pointer.tag_stack, [])
-    eq_(pointer.depth(), 0)
+    assert pointer.tag_stack == []
+    assert pointer.depth() == 0
 
     event, element = next(pointer)
-    eq_(pointer.tag_stack, ["foo"])
-    eq_(pointer.depth(), 1)
-    eq_(element.tag, "foo")
-    eq_(event, "start")
+    assert pointer.tag_stack == ["foo"]
+    assert pointer.depth() == 1
+    assert element.tag == "foo"
+    assert event == "start"
 
     event, element = next(pointer)
-    eq_(pointer.tag_stack, ["foo", "bar"])
-    eq_(pointer.depth(), 2)
-    eq_(element.tag, "bar")
-    eq_(event, "start")
+    assert pointer.tag_stack == ["foo", "bar"]
+    assert pointer.depth() == 2
+    assert element.tag == "bar"
+    assert event == "start"
 
     event, element = next(pointer)
-    eq_(pointer.tag_stack, ["foo", "bar", "herp"])
-    eq_(pointer.depth(), 3)
-    eq_(element.tag, "herp")
-    eq_(event, "start")
+    assert pointer.tag_stack == ["foo", "bar", "herp"]
+    assert pointer.depth() == 3
+    assert element.tag == "herp"
+    assert event == "start"
 
     event, element = next(pointer)
-    eq_(pointer.tag_stack, ["foo", "bar"])
-    eq_(pointer.depth(), 2)
-    eq_(element.tag, "herp")
-    eq_(event, "end")
+    assert pointer.tag_stack == ["foo", "bar"]
+    assert pointer.depth() == 2
+    assert element.tag == "herp"
+    assert event == "end"
 
     event, element = next(pointer)
-    eq_(pointer.tag_stack, ["foo"])
-    eq_(pointer.depth(), 1)
-    eq_(element.tag, "bar")
-    eq_(event, "end")
+    assert pointer.tag_stack == ["foo"]
+    assert pointer.depth() == 1
+    assert element.tag == "bar"
+    assert event == "end"
 
     event, element = next(pointer)
-    eq_(pointer.tag_stack, ["foo", "derp"])
-    eq_(pointer.depth(), 2)
-    eq_(element.tag, "derp")
-    eq_(event, "start")
+    assert pointer.tag_stack == ["foo", "derp"]
+    assert pointer.depth() == 2
+    assert element.tag == "derp"
+    assert event == "start"
 
     event, element = next(pointer)
-    eq_(pointer.tag_stack, ["foo"])
-    eq_(pointer.depth(), 1)
-    eq_(element.tag, "derp")
-    eq_(event, "end")
+    assert pointer.tag_stack == ["foo"]
+    assert pointer.depth() == 1
+    assert element.tag == "derp"
+    assert event == "end"
 
     event, element = next(pointer)
-    eq_(pointer.tag_stack, [])
-    eq_(pointer.depth(), 0)
-    eq_(element.tag, "foo")
-    eq_(event, "end")
+    assert pointer.tag_stack == []
+    assert pointer.depth() == 0
+    assert element.tag == "foo"
+    assert event == "end"
 
     try:
         event, element = next(pointer)
     except StopIteration:
-        return True
+        return None
 
     assert False, "Iteration did not stop as expected."
 
@@ -83,15 +81,15 @@ def test_iterator():
 
     bar_element = next(foo_iterator)
     bar_iterator = iter(bar_element)
-    eq_(bar_element.tag, "bar")
+    assert bar_element.tag == "bar"
 
     herp_element = next(bar_iterator)
-    eq_(herp_element.tag, "herp")
-    eq_(herp_element.text, "content")
+    assert herp_element.tag == "herp"
+    assert herp_element.text == "content"
 
     derp_element = next(foo_iterator)
-    eq_(derp_element.tag, "derp")
-    eq_(derp_element.attr("foo"), "bar")
+    assert derp_element.tag == "derp"
+    assert derp_element.attr("foo") == "bar"
 
 
 def test_skipping_iterator():
@@ -101,5 +99,5 @@ def test_skipping_iterator():
     next(foo_iterator)
 
     derp_element = next(foo_iterator)
-    eq_(derp_element.tag, "derp")
-    eq_(derp_element.attr("foo"), "bar")
+    assert derp_element.tag == "derp"
+    assert derp_element.attr("foo") == "bar"

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
     },
     long_description=open('README.md').read(),
     install_requires=requirements("requirements.txt"),
-    test_suite='nose.collector',
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
This migrates the test suite of mwxml to pytest and the stdlib's unittest, from nose. nose is now deprecated, and projects should now use pytest and/or unittest. As part of an effort in the nixpkgs project(NixOS/nixpkgs#326513), we are removing all usages of nose in our package set, and submitting patches to upstream projects to help them migrate more easily.

Thank you, and have a wonderful day! I would be glad to answer any questions you have about this PR.