### PR TITLE
Don't spew logs for namespace mismatches when there is no namespace_map

### DIFF
--- a/mwxml/about.py
+++ b/mwxml/about.py
@@ -1,5 +1,5 @@
 __name__ = "mwxml"
-__version__ = "0.3.5"
+__version__ = "0.3.6"
 __author__ = "Aaron Halfaker"
 __author_email__ = "aaron.halfaker@gmail.com"
 __description__ = "A set of utilities for processing MediaWiki XML dump data."

--- a/mwxml/iteration/page.py
+++ b/mwxml/iteration/page.py
@@ -95,7 +95,7 @@ class Page(mwtypes.Page):
 
         # Normalize title and extract namespace
         mapped_namespace, title = extract_namespace(page_name, namespace_map)
-        if namespace is not None and mapped_namespace != namespace:
+        if namespace is not None and mapped_namespace != namespace and namespace_map is not None:
             logger.warning("Namespace id conflict detected.  " +
                         "<title>={0}, ".format(page_name) +
                         "<namespace>={0}, ".format(namespace) +


### PR DESCRIPTION
`namespace_map` is missing when using the multistream format to load from part way through the file. Since we don't have a siteinfo in that case, it's best to not try to map this namespace back to the main one.