### PR TITLE
Use iterator type instead of range in iterator initialization

### DIFF
--- a/mwxml/iteration/dump.py
+++ b/mwxml/iteration/dump.py
@@ -65,7 +65,7 @@ class Dump:
         """
 
         # Should be a lazy generator of page info
-        self.items = items or range(0)
+        self.items = iter(items) if items is not None else iter(())
         """
         An iterator of :class:`mwxml.Page` and/or
         :class:`mwxml.LogItem` elements


### PR DESCRIPTION
I was using mwxml to write a script in VS Code. VS Code was complaining about the line `for item in dump`, saying: "Dump" is not iterable. "__next__" method not defined on type "range".

I changed `range(0)` in __init__ to `iter(())`, and this appears to fix that error.