### PR TITLE
Raise an error if siteinfo is not defined

### DIFF
--- a/mwxml/iteration/dump.py
+++ b/mwxml/iteration/dump.py
@@ -121,6 +121,10 @@ class Dump:
                 raise MalformedXML("Unexpected tag found when processing " +
                                    "a <mediawiki>: '{0}'".format(tag))
 
+        if site_info is None:
+            raise MalformedXML("<siteinfo> tag not found when processing " +
+                               "a <mediawiki>")
+
         namespace_map = None
         if site_info.namespaces is not None:
             namespace_map = {}


### PR DESCRIPTION
VS Code Pylance was complaining about this,
and with this defensive check, it no longer does.