### PR TITLE
Create a variable before it's used

### DIFF
--- a/mwxml/iteration/page.py
+++ b/mwxml/iteration/page.py
@@ -55,6 +55,7 @@ class Page(mwtypes.Page):
     @classmethod
     def from_element(cls, element, namespace_map=None):
         title = None
+        page_name = None
         namespace = None
         id = None
         redirect = None


### PR DESCRIPTION
Without this, VS Code Pylance complains that page_name may be unbound.