### PR TITLE
Initialize Page.__revisions to an empty iterator

### DIFF
--- a/mwxml/iteration/page.py
+++ b/mwxml/iteration/page.py
@@ -26,18 +26,14 @@ class Page(mwtypes.Page):
         super().initialize(*args, **kwargs)
 
         # Should be a lazy generator
-        self.__revisions = revisions
+        self.__revisions = revisions or iter(())
 
     def __iter__(self):
-        assert self.__revisions is not None
-
         for revision in self.__revisions:
             revision.page = self
             yield revision
 
     def __next__(self):
-        assert self.__revisions is not None
-
         revision = next(self.__revisions)
         revision.page = self
         return revision

--- a/mwxml/iteration/page.py
+++ b/mwxml/iteration/page.py
@@ -29,11 +29,15 @@ class Page(mwtypes.Page):
         self.__revisions = revisions
 
     def __iter__(self):
+        assert self.__revisions is not None
+
         for revision in self.__revisions:
             revision.page = self
             yield revision
 
     def __next__(self):
+        assert self.__revisions is not None
+
         revision = next(self.__revisions)
         revision.page = self
         return revision


### PR DESCRIPTION
This avoids errors when __revisions is not set and aligns with the existing pattern in Dump, where missing iterables are normalized to empty ones.

Without this, VS Code Pylance complains that self.__revisions might be None in __iter__ and __next__.